### PR TITLE
Add support for verifying base proof

### DIFF
--- a/lib/proofValue.js
+++ b/lib/proofValue.js
@@ -20,18 +20,39 @@ const CBOR_PREFIX_DERIVED = new Uint8Array([0xd9, 0x5d, 0x01]);
 const TAGS = [];
 TAGS[64] = _decodeUint8Array;
 
+function throwInvalidProofError(cause) {
+  const err = new TypeError(
+    'The proof does not include a valid "proofValue" property.');
+  err.cause = new Error(cause);
+  throw err;
+}
+
+export function checkForValidProof(proof) {
+  if(typeof proof?.proofValue !== 'string') {
+    throwInvalidProofError('"proof.proofValue" must be a string.');
+  }
+  if(proof.proofValue[0] !== 'u') {
+    throwInvalidProofError('Only base64url multibase encoding is supported.');
+  }
+}
+
+export function isBaseProofValue(proof) {
+  checkForValidProof(proof);
+  const proofValue = base64url.decode(proof.proofValue.slice(1));
+  return _startsWithBytes(proofValue, CBOR_PREFIX_BASE);
+}
+
+export function isDerivedProofValue(proof) {
+  checkForValidProof(proof);
+  const proofValue = base64url.decode(proof.proofValue.slice(1));
+  return _startsWithBytes(proofValue, CBOR_PREFIX_DERIVED);
+}
+
 export function parseBaseProofValue({proof} = {}) {
   try {
-    if(typeof proof?.proofValue !== 'string') {
-      throw new TypeError('"proof.proofValue" must be a string.');
-    }
-    if(proof.proofValue[0] !== 'u') {
-      throw new Error('Only base64url multibase encoding is supported.');
-    }
-
     // decode from base64url
     const proofValue = base64url.decode(proof.proofValue.slice(1));
-    if(!_startsWithBytes(proofValue, CBOR_PREFIX_BASE)) {
+    if(!isBaseProofValue(proof)) {
       throw new TypeError('"proof.proofValue" must be a base proof.');
     }
 
@@ -59,16 +80,9 @@ export function parseBaseProofValue({proof} = {}) {
 
 export function parseDisclosureProofValue({proof} = {}) {
   try {
-    if(typeof proof?.proofValue !== 'string') {
-      throw new TypeError('"proof.proofValue" must be a string.');
-    }
-    if(proof.proofValue[0] !== 'u') {
-      throw new Error('Only base64url multibase encoding is supported.');
-    }
-
     // decode from base64url
     const proofValue = base64url.decode(proof.proofValue.slice(1));
-    if(!_startsWithBytes(proofValue, CBOR_PREFIX_DERIVED)) {
+    if(!isDerivedProofValue(proof)) {
       throw new TypeError('"proof.proofValue" must be a derived proof.');
     }
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -4,14 +4,21 @@
 import * as base58 from 'base58-universal';
 import * as EcdsaMultikey from '@digitalbazaar/ecdsa-multikey';
 import {
+  createHmac,
+  createHmacIdLabelMapFunction,
   createLabelMapFunction,
   hashCanonizedProof,
   hashMandatory,
   labelReplacementCanonicalizeJsonLd,
-  stringToUtf8Bytes
+  selectJsonLd,
+  stringToUtf8Bytes,
 } from '@digitalbazaar/di-sd-primitives';
 import {
-  parseDisclosureProofValue, serializeBaseVerifyData
+  isBaseProofValue,
+  isDerivedProofValue,
+  parseBaseProofValue,
+  parseDisclosureProofValue,
+  serializeBaseVerifyData,
 } from './proofValue.js';
 import {name} from './name.js';
 import {requiredAlgorithm} from './requiredAlgorithm.js';
@@ -45,6 +52,77 @@ async function _createVerifyData({
     throw new TypeError(`"cryptosuite.name" must be "${name}".`);
   }
 
+  if(isBaseProofValue(proof)) {
+    return _createBaseProofVerifyData({document, proof, documentLoader});
+  }
+
+  if(isDerivedProofValue(proof)) {
+    return _createDerivedProofVerifyData({document, proof, documentLoader});
+  }
+
+  throw new Error(`Unsupported proof type detected. Must be base or derived
+    proof`);
+}
+
+async function _createBaseProofVerifyData({
+  document, proof, documentLoader
+}) {
+  // 1. Generate `proofHash` in parallel.
+  const options = {documentLoader};
+  const proofHashPromise = hashCanonizedProof({document, proof, options})
+    .catch(e => e);
+
+  // 2. Parse disclosure `proof` to get parameters to verify.
+  const {
+    baseSignature, hmacKey, publicKey, signatures, mandatoryPointers,
+  } = await parseBaseProofValue({proof});
+
+  // 3. Canonicalize document using label map.
+  const hmac = await createHmac({key: hmacKey});
+  const labelMapFactoryFunction = createHmacIdLabelMapFunction({hmac});
+  const nquads = await labelReplacementCanonicalizeJsonLd({
+    document,
+    labelMapFactoryFunction,
+    options
+  });
+
+  // 4. If mandatory pointers were selected, canonicalize document using
+  // mandatory pointers again
+  let mandatoryNquads = [];
+  if(mandatoryPointers.length) {
+    const filteredDocument = await selectJsonLd({
+      document,
+      pointers: mandatoryPointers
+    });
+    mandatoryNquads = await labelReplacementCanonicalizeJsonLd({
+      document: filteredDocument,
+      labelMapFactoryFunction,
+      options
+    });
+  }
+
+  // 4. Hash any mandatory N-Quads.
+  const nonMandatory = nquads.filter(nquad => !mandatoryNquads.includes(nquad));
+  const {mandatoryHash} = await hashMandatory({mandatory: mandatoryNquads});
+
+  // 5. Return data used by cryptosuite to verify.
+  const proofHash = await proofHashPromise;
+  if(proofHash instanceof Error) {
+    throw proofHash;
+  }
+  return {
+    baseSignature,
+    mandatoryHash,
+    nonMandatory,
+    proofHash,
+    publicKey,
+    signatures,
+  };
+}
+
+async function _createDerivedProofVerifyData({
+  document, proof, documentLoader
+}) {
   // 1. Generate `proofHash` in parallel.
   const options = {documentLoader};
   const proofHashPromise = hashCanonizedProof({document, proof, options})

--- a/test/verify-vc2.spec.js
+++ b/test/verify-vc2.spec.js
@@ -65,10 +65,22 @@ describe('verify VCDM 2.0 example VC', () => {
     }
   });
 
-  it('should verify', async () => {
+  it('should verify derived credential', async () => {
     const cryptosuite = createVerifyCryptosuite();
     const suite = new DataIntegrityProof({cryptosuite});
     const result = await jsigs.verify(revealedEmployeeCredential, {
+      suite,
+      purpose: new AssertionProofPurpose(),
+      documentLoader
+    });
+
+    expect(result.verified).to.be.true;
+  });
+
+  it('should verify non derived credential', async () => {
+    const cryptosuite = createVerifyCryptosuite();
+    const suite = new DataIntegrityProof({cryptosuite});
+    const result = await jsigs.verify(signedEmployeeCredential, {
       suite,
       purpose: new AssertionProofPurpose(),
       documentLoader

--- a/test/verify.spec.js
+++ b/test/verify.spec.js
@@ -136,7 +136,6 @@ describe('verify()', () => {
         });
 
         const {errors} = result.error;
-
         expect(result.verified).to.be.false;
         expect(errors[0].name).to.equal('TypeError');
         expect(errors[0].cause.message).to.include('Only base64url');
@@ -183,7 +182,7 @@ describe('verify()', () => {
         expect(errors[0].name).to.equal('NotFoundError');
       });
 
-    it('should fail verifying a base proof', async () => {
+    it('should verify a base proof', async () => {
       const cryptosuite = createVerifyCryptosuite();
       const suite = new DataIntegrityProof({cryptosuite});
       const result = await jsigs.verify(signedAlumniCredential, {
@@ -192,13 +191,7 @@ describe('verify()', () => {
         documentLoader
       });
 
-      expect(result.verified).to.be.false;
-      const {error} = result.results[0];
-
-      expect(result.verified).to.be.false;
-      expect(error.name).to.equal('TypeError');
-      expect(error.message).to.equal(
-        'The proof does not include a valid "proofValue" property.');
+      expect(result.verified).to.be.true;
     });
 
     it('should verify with only the credential subject ID', async () => {


### PR DESCRIPTION
When trying to verify credentials with base proof created using the `ecdsa-sd-2023-cryptosuite` library, verification fails because only derived proofs can be verified. Since the `proof.cryptosuite` of the base proof is already `ecdsa-sd-2023`, it would be beneficial to use the same library for verifying both the base proof and the derived proof.

This pull request (PR) splits the `_createBaseProofVerifyData` function into two parts: one for base proofs and one for derived proofs.

## Details

- Added new functions to `lib/proofValue.js`:
  - `checkForValidProof`: Checks if `proofValue` is a string and ensures it is base64url encoded.
  - `isBaseProofValue`
  - `isDerivedProofValue`

- Added new functions to `lib/verify`:
  - `_createVerifyData`: Uses `isBaseProofValue` and `isDerivedProofValue` to call either `_createBaseProofVerifyData` or `_createDerivedProofVerifyData`.
  - `_createBaseProofVerifyData`: Parses the base proof value and determines required and non-required n-quads.
  - `_createDerivedProofVerifyData`: Original verify function.

- Adjusted tests to accommodate changes.

## Questions

I hope these changes align with the interests of the repository. Please let me know if you need any further adjustments.
