### PR TITLE
Add support to confirm base proofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/ecdsa-sd-2023-cryptosuite Changelog
 
+## 3.4.0 - 2024-08-dd
+
+### Added
+- Add `createConfirmCryptosuite()` to enable confirming base proofs.
+
 ## 3.3.0 - 2024-08-17
 
 ### Added

--- a/lib/confirm.js
+++ b/lib/confirm.js
@@ -1,0 +1,83 @@
+/*!
+ * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import {
+  createHmac,
+  createHmacIdLabelMapFunction,
+  hashCanonizedProof,
+  hashMandatory,
+  labelReplacementCanonicalizeJsonLd,
+  selectJsonLd
+} from '@digitalbazaar/di-sd-primitives';
+import {createVerifier} from './verify.js';
+import {name} from './name.js';
+import {parseBaseProofValue} from './proofValue.js';
+import {requiredAlgorithm} from './requiredAlgorithm.js';
+
+export function createConfirmCryptosuite() {
+  return {
+    name,
+    requiredAlgorithm,
+    createVerifier,
+    createVerifyData: _createVerifyData
+  };
+}
+
+async function _createVerifyData({
+  cryptosuite, document, proof, documentLoader
+}) {
+  if(cryptosuite?.name !== name) {
+    throw new TypeError(`"cryptosuite.name" must be "${name}".`);
+  }
+
+  // 1. Generate `proofHash` in parallel.
+  const options = {documentLoader};
+  const proofHashPromise = hashCanonizedProof({document, proof, options})
+    .catch(e => e);
+
+  // 2. Parse base `proof` to get parameters to verify.
+  const {
+    baseSignature, hmacKey, publicKey, signatures, mandatoryPointers,
+  } = await parseBaseProofValue({proof});
+
+  // 3. Canonicalize document using hmac generated label map.
+  const hmac = await createHmac({key: hmacKey});
+  const labelMapFactoryFunction = createHmacIdLabelMapFunction({hmac});
+  const nquads = await labelReplacementCanonicalizeJsonLd({
+    document,
+    labelMapFactoryFunction,
+    options
+  });
+
+  // 4. Regenerate any canonical mandatory N-Quads.
+  let mandatory;
+  if(mandatoryPointers.length === 0) {
+    mandatory = [];
+  } else {
+    const filteredDocument = await selectJsonLd({
+      document,
+      pointers: mandatoryPointers
+    });
+    mandatory = await labelReplacementCanonicalizeJsonLd({
+      document: filteredDocument,
+      labelMapFactoryFunction,
+      options
+    });
+  }
+
+  // 5. Separate out non-mandatory N-Quads.
+  const nonMandatory = nquads.filter(nquad => !mandatory.includes(nquad));
+
+  // 6. Hash any mandatory N-Quads.
+  const {mandatoryHash} = await hashMandatory({mandatory});
+
+  // 7. Return data used by cryptosuite to confirm base proof.
+  const proofHash = await proofHashPromise;
+  if(proofHash instanceof Error) {
+    throw proofHash;
+  }
+  return {
+    baseSignature, proofHash, publicKey, signatures, nonMandatory,
+    mandatoryHash
+  };
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 /*!
- * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
-*/
+ * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+export {createConfirmCryptosuite} from './confirm.js';
 export {createDiscloseCryptosuite} from './disclose.js';
 export {createSignCryptosuite} from './sign.js';
 export {createVerifyCryptosuite} from './verify.js';

--- a/lib/proofValue.js
+++ b/lib/proofValue.js
@@ -20,18 +20,39 @@ const CBOR_PREFIX_DERIVED = new Uint8Array([0xd9, 0x5d, 0x01]);
 const TAGS = [];
 TAGS[64] = _decodeUint8Array;
 
+function throwInvalidProofError(cause) {
+  const err = new TypeError(
+    'The proof does not include a valid "proofValue" property.');
+  err.cause = new Error(cause);
+  throw err;
+}
+
+export function checkForValidProof(proof) {
+  if(typeof proof?.proofValue !== 'string') {
+    throwInvalidProofError('"proof.proofValue" must be a string.');
+  }
+  if(proof.proofValue[0] !== 'u') {
+    throwInvalidProofError('Only base64url multibase encoding is supported.');
+  }
+}
+
+export function isBaseProofValue(proof) {
+  checkForValidProof(proof);
+  const proofValue = base64url.decode(proof.proofValue.slice(1));
+  return _startsWithBytes(proofValue, CBOR_PREFIX_BASE);
+}
+
+export function isDerivedProofValue(proof) {
+  checkForValidProof(proof);
+  const proofValue = base64url.decode(proof.proofValue.slice(1));
+  return _startsWithBytes(proofValue, CBOR_PREFIX_DERIVED);
+}
+
 export function parseBaseProofValue({proof} = {}) {
   try {
-    if(typeof proof?.proofValue !== 'string') {
-      throw new TypeError('"proof.proofValue" must be a string.');
-    }
-    if(proof.proofValue[0] !== 'u') {
-      throw new Error('Only base64url multibase encoding is supported.');
-    }
-
     // decode from base64url
     const proofValue = base64url.decode(proof.proofValue.slice(1));
-    if(!_startsWithBytes(proofValue, CBOR_PREFIX_BASE)) {
+    if(!isBaseProofValue(proof)) {
       throw new TypeError('"proof.proofValue" must be a base proof.');
     }
 
@@ -59,16 +80,9 @@ export function parseBaseProofValue({proof} = {}) {
 
 export function parseDisclosureProofValue({proof} = {}) {
   try {
-    if(typeof proof?.proofValue !== 'string') {
-      throw new TypeError('"proof.proofValue" must be a string.');
-    }
-    if(proof.proofValue[0] !== 'u') {
-      throw new Error('Only base64url multibase encoding is supported.');
-    }
-
     // decode from base64url
     const proofValue = base64url.decode(proof.proofValue.slice(1));
-    if(!_startsWithBytes(proofValue, CBOR_PREFIX_DERIVED)) {
+    if(!isDerivedProofValue(proof)) {
       throw new TypeError('"proof.proofValue" must be a derived proof.');
     }
 

--- a/lib/proofValue.js
+++ b/lib/proofValue.js
@@ -20,39 +20,11 @@ const CBOR_PREFIX_DERIVED = new Uint8Array([0xd9, 0x5d, 0x01]);
 const TAGS = [];
 TAGS[64] = _decodeUint8Array;
 
-function throwInvalidProofError(cause) {
-  const err = new TypeError(
-    'The proof does not include a valid "proofValue" property.');
-  err.cause = new Error(cause);
-  throw err;
-}
-
-export function checkForValidProof(proof) {
-  if(typeof proof?.proofValue !== 'string') {
-    throwInvalidProofError('"proof.proofValue" must be a string.');
-  }
-  if(proof.proofValue[0] !== 'u') {
-    throwInvalidProofError('Only base64url multibase encoding is supported.');
-  }
-}
-
-export function isBaseProofValue(proof) {
-  checkForValidProof(proof);
-  const proofValue = base64url.decode(proof.proofValue.slice(1));
-  return _startsWithBytes(proofValue, CBOR_PREFIX_BASE);
-}
-
-export function isDerivedProofValue(proof) {
-  checkForValidProof(proof);
-  const proofValue = base64url.decode(proof.proofValue.slice(1));
-  return _startsWithBytes(proofValue, CBOR_PREFIX_DERIVED);
-}
-
 export function parseBaseProofValue({proof} = {}) {
   try {
     // decode from base64url
     const proofValue = base64url.decode(proof.proofValue.slice(1));
-    if(!isBaseProofValue(proof)) {
+    if(!_isBaseProofValue(proof)) {
       throw new TypeError('"proof.proofValue" must be a base proof.');
     }
 
@@ -82,7 +54,7 @@ export function parseDisclosureProofValue({proof} = {}) {
   try {
     // decode from base64url
     const proofValue = base64url.decode(proof.proofValue.slice(1));
-    if(!isDerivedProofValue(proof)) {
+    if(!_isDerivedProofValue(proof)) {
       throw new TypeError('"proof.proofValue" must be a derived proof.');
     }
 
@@ -171,6 +143,19 @@ export function serializeDisclosureProofValue({
   return `u${base64url.encode(cbor)}`;
 }
 
+function _assertProofValue(proof) {
+  if(typeof proof?.proofValue !== 'string') {
+    throw new TypeError(
+      'The proof does not include a valid "proofValue" property; ' +
+      '"proofValue" must be a string.');
+  }
+  if(proof.proofValue[0] !== 'u') {
+    throw new TypeError(
+      'The proof does not include a valid "proofValue" property; ' +
+      'only base64url multibase encoding is supported.');
+  }
+}
+
 function _compressLabelMap(labelMap) {
   const map = new Map();
   for(const [k, v] of labelMap.entries()) {
@@ -195,6 +180,18 @@ function _decompressLabelMap(compressedLabelMap) {
     map.set(`c14n${k}`, `u${base64url.encode(v)}`);
   }
   return map;
+}
+
+function _isBaseProofValue(proof) {
+  _assertProofValue(proof);
+  const proofValue = base64url.decode(proof.proofValue.slice(1));
+  return _startsWithBytes(proofValue, CBOR_PREFIX_BASE);
+}
+
+function _isDerivedProofValue(proof) {
+  _assertProofValue(proof);
+  const proofValue = base64url.decode(proof.proofValue.slice(1));
+  return _startsWithBytes(proofValue, CBOR_PREFIX_DERIVED);
 }
 
 function _startsWithBytes(buffer, prefix) {

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -15,10 +15,12 @@ import {
   serializeBaseProofValue,
   serializeBaseVerifyData
 } from './proofValue.js';
-import {name} from './name.js';
 import {requiredAlgorithm as _requiredAlgorithm} from './requiredAlgorithm.js';
+import {name} from './name.js';
 
-export function createSignCryptosuite({mandatoryPointers = [], requiredAlgorithm = _requiredAlgorithm} = {}) {
+export function createSignCryptosuite({
+  mandatoryPointers = [], requiredAlgorithm = _requiredAlgorithm
+} = {}) {
   const options = {mandatoryPointers};
   return {
     name,

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -8,7 +8,7 @@ import {
   hashCanonizedProof,
   hashMandatory,
   labelReplacementCanonicalizeJsonLd,
-  stringToUtf8Bytes,
+  stringToUtf8Bytes
 } from '@digitalbazaar/di-sd-primitives';
 import {
   parseDisclosureProofValue,

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -4,14 +4,21 @@
 import * as base58 from 'base58-universal';
 import * as EcdsaMultikey from '@digitalbazaar/ecdsa-multikey';
 import {
+  createHmac,
+  createHmacIdLabelMapFunction,
   createLabelMapFunction,
   hashCanonizedProof,
   hashMandatory,
   labelReplacementCanonicalizeJsonLd,
-  stringToUtf8Bytes
+  selectJsonLd,
+  stringToUtf8Bytes,
 } from '@digitalbazaar/di-sd-primitives';
 import {
-  parseDisclosureProofValue, serializeBaseVerifyData
+  isBaseProofValue,
+  isDerivedProofValue,
+  parseBaseProofValue,
+  parseDisclosureProofValue,
+  serializeBaseVerifyData,
 } from './proofValue.js';
 import {name} from './name.js';
 import {requiredAlgorithm as _requiredAlgorithm} from './requiredAlgorithm.js';
@@ -45,6 +52,77 @@ async function _createVerifyData({
     throw new TypeError(`"cryptosuite.name" must be "${name}".`);
   }
 
+  if(isBaseProofValue(proof)) {
+    return _createBaseProofVerifyData({document, proof, documentLoader});
+  }
+
+  if(isDerivedProofValue(proof)) {
+    return _createDerivedProofVerifyData({document, proof, documentLoader});
+  }
+
+  throw new Error(`Unsupported proof type detected. Must be base or derived
+    proof`);
+}
+
+async function _createBaseProofVerifyData({
+  document, proof, documentLoader
+}) {
+  // 1. Generate `proofHash` in parallel.
+  const options = {documentLoader};
+  const proofHashPromise = hashCanonizedProof({document, proof, options})
+    .catch(e => e);
+
+  // 2. Parse disclosure `proof` to get parameters to verify.
+  const {
+    baseSignature, hmacKey, publicKey, signatures, mandatoryPointers,
+  } = await parseBaseProofValue({proof});
+
+  // 3. Canonicalize document using label map.
+  const hmac = await createHmac({key: hmacKey});
+  const labelMapFactoryFunction = createHmacIdLabelMapFunction({hmac});
+  const nquads = await labelReplacementCanonicalizeJsonLd({
+    document,
+    labelMapFactoryFunction,
+    options
+  });
+
+  // 4. If mandatory pointers were selected, canonicalize document using
+  // mandatory pointers again
+  let mandatoryNquads = [];
+  if(mandatoryPointers.length) {
+    const filteredDocument = await selectJsonLd({
+      document,
+      pointers: mandatoryPointers
+    });
+    mandatoryNquads = await labelReplacementCanonicalizeJsonLd({
+      document: filteredDocument,
+      labelMapFactoryFunction,
+      options
+    });
+  }
+
+  // 4. Hash any mandatory N-Quads.
+  const nonMandatory = nquads.filter(nquad => !mandatoryNquads.includes(nquad));
+  const {mandatoryHash} = await hashMandatory({mandatory: mandatoryNquads});
+
+  // 5. Return data used by cryptosuite to verify.
+  const proofHash = await proofHashPromise;
+  if(proofHash instanceof Error) {
+    throw proofHash;
+  }
+  return {
+    baseSignature,
+    mandatoryHash,
+    nonMandatory,
+    proofHash,
+    publicKey,
+    signatures,
+  };
+}
+
+async function _createDerivedProofVerifyData({
+  document, proof, documentLoader
+}) {
   // 1. Generate `proofHash` in parallel.
   const options = {documentLoader};
   const proofHashPromise = hashCanonizedProof({document, proof, options})

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -14,10 +14,12 @@ import {
   parseDisclosureProofValue,
   serializeBaseVerifyData
 } from './proofValue.js';
-import {name} from './name.js';
 import {requiredAlgorithm as _requiredAlgorithm} from './requiredAlgorithm.js';
+import {name} from './name.js';
 
-export function createVerifyCryptosuite({requiredAlgorithm = _requiredAlgorithm} = {}) {
+export function createVerifyCryptosuite({
+  requiredAlgorithm = _requiredAlgorithm
+} = {}) {
   return {
     name,
     requiredAlgorithm,

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,24 +1,18 @@
 /*!
- * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as base58 from 'base58-universal';
 import * as EcdsaMultikey from '@digitalbazaar/ecdsa-multikey';
 import {
-  createHmac,
-  createHmacIdLabelMapFunction,
   createLabelMapFunction,
   hashCanonizedProof,
   hashMandatory,
   labelReplacementCanonicalizeJsonLd,
-  selectJsonLd,
   stringToUtf8Bytes,
 } from '@digitalbazaar/di-sd-primitives';
 import {
-  isBaseProofValue,
-  isDerivedProofValue,
-  parseBaseProofValue,
   parseDisclosureProofValue,
-  serializeBaseVerifyData,
+  serializeBaseVerifyData
 } from './proofValue.js';
 import {name} from './name.js';
 import {requiredAlgorithm as _requiredAlgorithm} from './requiredAlgorithm.js';
@@ -52,77 +46,6 @@ async function _createVerifyData({
     throw new TypeError(`"cryptosuite.name" must be "${name}".`);
   }
 
-  if(isBaseProofValue(proof)) {
-    return _createBaseProofVerifyData({document, proof, documentLoader});
-  }
-
-  if(isDerivedProofValue(proof)) {
-    return _createDerivedProofVerifyData({document, proof, documentLoader});
-  }
-
-  throw new Error(`Unsupported proof type detected. Must be base or derived
-    proof`);
-}
-
-async function _createBaseProofVerifyData({
-  document, proof, documentLoader
-}) {
-  // 1. Generate `proofHash` in parallel.
-  const options = {documentLoader};
-  const proofHashPromise = hashCanonizedProof({document, proof, options})
-    .catch(e => e);
-
-  // 2. Parse disclosure `proof` to get parameters to verify.
-  const {
-    baseSignature, hmacKey, publicKey, signatures, mandatoryPointers,
-  } = await parseBaseProofValue({proof});
-
-  // 3. Canonicalize document using label map.
-  const hmac = await createHmac({key: hmacKey});
-  const labelMapFactoryFunction = createHmacIdLabelMapFunction({hmac});
-  const nquads = await labelReplacementCanonicalizeJsonLd({
-    document,
-    labelMapFactoryFunction,
-    options
-  });
-
-  // 4. If mandatory pointers were selected, canonicalize document using
-  // mandatory pointers again
-  let mandatoryNquads = [];
-  if(mandatoryPointers.length) {
-    const filteredDocument = await selectJsonLd({
-      document,
-      pointers: mandatoryPointers
-    });
-    mandatoryNquads = await labelReplacementCanonicalizeJsonLd({
-      document: filteredDocument,
-      labelMapFactoryFunction,
-      options
-    });
-  }
-
-  // 4. Hash any mandatory N-Quads.
-  const nonMandatory = nquads.filter(nquad => !mandatoryNquads.includes(nquad));
-  const {mandatoryHash} = await hashMandatory({mandatory: mandatoryNquads});
-
-  // 5. Return data used by cryptosuite to verify.
-  const proofHash = await proofHashPromise;
-  if(proofHash instanceof Error) {
-    throw proofHash;
-  }
-  return {
-    baseSignature,
-    mandatoryHash,
-    nonMandatory,
-    proofHash,
-    publicKey,
-    signatures,
-  };
-}
-
-async function _createDerivedProofVerifyData({
-  document, proof, documentLoader
-}) {
   // 1. Generate `proofHash` in parallel.
   const options = {documentLoader};
   const proofHashPromise = hashCanonizedProof({document, proof, options})

--- a/test/confirm-vc2.spec.js
+++ b/test/confirm-vc2.spec.js
@@ -1,0 +1,62 @@
+/*!
+ * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as EcdsaMultikey from '@digitalbazaar/ecdsa-multikey';
+import * as ecdsaSd2023Cryptosuite from '../lib/index.js';
+import {
+  ecdsaMultikeyKeyPair,
+  employeeCredential
+} from './mock-data.js';
+import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
+import {expect} from 'chai';
+import jsigs from 'jsonld-signatures';
+import {klona} from 'klona';
+import {loader} from './documentLoader.js';
+
+const {
+  createSignCryptosuite,
+  createConfirmCryptosuite
+} = ecdsaSd2023Cryptosuite;
+
+const {purposes: {AssertionProofPurpose}} = jsigs;
+
+const documentLoader = loader.build();
+
+describe('confirm VCDM 2.0 example VC', () => {
+  let signedEmployeeCredential;
+  before(async () => {
+    const cryptosuite = createSignCryptosuite({
+      mandatoryPointers: [
+        '/issuer',
+        '/type',
+        '/validFrom',
+        '/validUntil'
+      ]
+    });
+    const unsignedCredential = klona(employeeCredential);
+
+    const keyPair = await EcdsaMultikey.from({...ecdsaMultikeyKeyPair});
+    const date = unsignedCredential.validFrom;
+    const suite = new DataIntegrityProof({
+      signer: keyPair.signer(), date, cryptosuite
+    });
+
+    signedEmployeeCredential = await jsigs.sign(unsignedCredential, {
+      suite,
+      purpose: new AssertionProofPurpose(),
+      documentLoader
+    });
+  });
+
+  it('should confirm base credential', async () => {
+    const cryptosuite = createConfirmCryptosuite();
+    const suite = new DataIntegrityProof({cryptosuite});
+    const result = await jsigs.verify(signedEmployeeCredential, {
+      suite,
+      purpose: new AssertionProofPurpose(),
+      documentLoader
+    });
+
+    expect(result.verified).to.be.true;
+  });
+});

--- a/test/confirm.spec.js
+++ b/test/confirm.spec.js
@@ -1,0 +1,57 @@
+/*!
+ * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as EcdsaMultikey from '@digitalbazaar/ecdsa-multikey';
+import * as ecdsaSd2023Cryptosuite from '../lib/index.js';
+import {
+  alumniCredential,
+  ecdsaMultikeyKeyPair
+} from './mock-data.js';
+import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
+import {expect} from 'chai';
+import jsigs from 'jsonld-signatures';
+import {klona} from 'klona';
+import {loader} from './documentLoader.js';
+
+const {
+  createConfirmCryptosuite,
+  createSignCryptosuite
+} = ecdsaSd2023Cryptosuite;
+
+const {purposes: {AssertionProofPurpose}} = jsigs;
+
+const documentLoader = loader.build();
+
+describe('verify()', () => {
+  describe('basic', () => {
+    let signedAlumniCredential;
+    before(async () => {
+      const cryptosuite = createSignCryptosuite();
+      const unsignedCredential = klona(alumniCredential);
+
+      const keyPair = await EcdsaMultikey.from({...ecdsaMultikeyKeyPair});
+      const date = '2023-03-01T21:29:24Z';
+      const suite = new DataIntegrityProof({
+        signer: keyPair.signer(), date, cryptosuite
+      });
+
+      signedAlumniCredential = await jsigs.sign(unsignedCredential, {
+        suite,
+        purpose: new AssertionProofPurpose(),
+        documentLoader
+      });
+    });
+
+    it('should confirm a base proof', async () => {
+      const cryptosuite = createConfirmCryptosuite();
+      const suite = new DataIntegrityProof({cryptosuite});
+      const result = await jsigs.verify(signedAlumniCredential, {
+        suite,
+        purpose: new AssertionProofPurpose(),
+        documentLoader
+      });
+
+      expect(result.verified).to.be.true;
+    });
+  });
+});

--- a/test/ecdsaSd2023Cryptosuite.spec.js
+++ b/test/ecdsaSd2023Cryptosuite.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as EcdsaMultikey from '@digitalbazaar/ecdsa-multikey';
 import * as ecdsaSd2023Cryptosuite from '../lib/index.js';
@@ -7,6 +7,7 @@ import {ecdsaMultikeyKeyPair} from './mock-data.js';
 import {expect} from 'chai';
 
 const {
+  createConfirmCryptosuite,
   createDiscloseCryptosuite,
   createSignCryptosuite,
   createVerifyCryptosuite
@@ -16,9 +17,21 @@ describe('ecdsa-sd-2023 cryptosuite', () => {
   describe('exports', () => {
     it('should have proper exports', async () => {
       should.exist(ecdsaSd2023Cryptosuite);
+      ecdsaSd2023Cryptosuite.createConfirmCryptosuite.should.be.a('function');
       ecdsaSd2023Cryptosuite.createDiscloseCryptosuite.should.be.a('function');
       ecdsaSd2023Cryptosuite.createSignCryptosuite.should.be.a('function');
       ecdsaSd2023Cryptosuite.createVerifyCryptosuite.should.be.a('function');
+    });
+  });
+
+  describe('createConfirmCryptosuite', () => {
+    it('should have proper exports', async () => {
+      const cryptosuite = await createConfirmCryptosuite();
+      should.exist(cryptosuite);
+      cryptosuite.name.should.equal('ecdsa-sd-2023');
+      cryptosuite.requiredAlgorithm.should.equal('P-256');
+      cryptosuite.createVerifier.should.be.a('function');
+      cryptosuite.createVerifyData.should.be.a('function');
     });
   });
 

--- a/test/verify-vc2.spec.js
+++ b/test/verify-vc2.spec.js
@@ -65,10 +65,22 @@ describe('verify VCDM 2.0 example VC', () => {
     }
   });
 
-  it('should verify', async () => {
+  it('should verify derived credential', async () => {
     const cryptosuite = createVerifyCryptosuite();
     const suite = new DataIntegrityProof({cryptosuite});
     const result = await jsigs.verify(revealedEmployeeCredential, {
+      suite,
+      purpose: new AssertionProofPurpose(),
+      documentLoader
+    });
+
+    expect(result.verified).to.be.true;
+  });
+
+  it('should verify non derived credential', async () => {
+    const cryptosuite = createVerifyCryptosuite();
+    const suite = new DataIntegrityProof({cryptosuite});
+    const result = await jsigs.verify(signedEmployeeCredential, {
       suite,
       purpose: new AssertionProofPurpose(),
       documentLoader

--- a/test/verify-vc2.spec.js
+++ b/test/verify-vc2.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as EcdsaMultikey from '@digitalbazaar/ecdsa-multikey';
 import * as ecdsaSd2023Cryptosuite from '../lib/index.js';
@@ -65,22 +65,10 @@ describe('verify VCDM 2.0 example VC', () => {
     }
   });
 
-  it('should verify derived credential', async () => {
+  it('should verify', async () => {
     const cryptosuite = createVerifyCryptosuite();
     const suite = new DataIntegrityProof({cryptosuite});
     const result = await jsigs.verify(revealedEmployeeCredential, {
-      suite,
-      purpose: new AssertionProofPurpose(),
-      documentLoader
-    });
-
-    expect(result.verified).to.be.true;
-  });
-
-  it('should verify non derived credential', async () => {
-    const cryptosuite = createVerifyCryptosuite();
-    const suite = new DataIntegrityProof({cryptosuite});
-    const result = await jsigs.verify(signedEmployeeCredential, {
       suite,
       purpose: new AssertionProofPurpose(),
       documentLoader

--- a/test/verify.spec.js
+++ b/test/verify.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as EcdsaMultikey from '@digitalbazaar/ecdsa-multikey';
 import * as ecdsaSd2023Cryptosuite from '../lib/index.js';
@@ -138,7 +138,7 @@ describe('verify()', () => {
         const {errors} = result.error;
         expect(result.verified).to.be.false;
         expect(errors[0].name).to.equal('TypeError');
-        expect(errors[0].cause.message).to.include('Only base64url');
+        expect(errors[0].cause.message).to.include('only base64url');
       }
     );
 
@@ -157,7 +157,6 @@ describe('verify()', () => {
         });
 
         const {errors} = result.error;
-
         expect(result.verified).to.be.false;
         expect(errors[0].name).to.equal('NotFoundError');
       });
@@ -177,12 +176,11 @@ describe('verify()', () => {
         });
 
         const {errors} = result.error;
-
         expect(result.verified).to.be.false;
         expect(errors[0].name).to.equal('NotFoundError');
       });
 
-    it('should verify a base proof', async () => {
+    it('should fail verifying a base proof', async () => {
       const cryptosuite = createVerifyCryptosuite();
       const suite = new DataIntegrityProof({cryptosuite});
       const result = await jsigs.verify(signedAlumniCredential, {
@@ -191,7 +189,11 @@ describe('verify()', () => {
         documentLoader
       });
 
-      expect(result.verified).to.be.true;
+      expect(result.verified).to.be.false;
+      const {error} = result.results[0];
+      expect(error.name).to.equal('TypeError');
+      expect(error.message).to.equal(
+        'The proof does not include a valid "proofValue" property.');
     });
 
     it('should verify with only the credential subject ID', async () => {

--- a/test/verify.spec.js
+++ b/test/verify.spec.js
@@ -136,7 +136,6 @@ describe('verify()', () => {
         });
 
         const {errors} = result.error;
-
         expect(result.verified).to.be.false;
         expect(errors[0].name).to.equal('TypeError');
         expect(errors[0].cause.message).to.include('Only base64url');
@@ -183,7 +182,7 @@ describe('verify()', () => {
         expect(errors[0].name).to.equal('NotFoundError');
       });
 
-    it('should fail verifying a base proof', async () => {
+    it('should verify a base proof', async () => {
       const cryptosuite = createVerifyCryptosuite();
       const suite = new DataIntegrityProof({cryptosuite});
       const result = await jsigs.verify(signedAlumniCredential, {
@@ -192,13 +191,7 @@ describe('verify()', () => {
         documentLoader
       });
 
-      expect(result.verified).to.be.false;
-      const {error} = result.results[0];
-
-      expect(result.verified).to.be.false;
-      expect(error.name).to.equal('TypeError');
-      expect(error.message).to.equal(
-        'The proof does not include a valid "proofValue" property.');
+      expect(result.verified).to.be.true;
     });
 
     it('should verify with only the credential subject ID', async () => {


### PR DESCRIPTION
The  code here needs some slight reworking to add a `createConfirmCryptosuite` that is used to confirm base proofs -- to be distinguished from `createVerifyCryptosuite` which is used to verify derived proofs.